### PR TITLE
Embed fyne.Theme interface to inherit default implementation

### DIFF
--- a/v2/main.go
+++ b/v2/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	a := app.New()
-	a.Settings().SetTheme(&myTheme{})
+	a.Settings().SetTheme(MyTheme())
 	w := a.NewWindow("font")
 	w.Resize(fyne.NewSize(300, 200))
 	w.SetContent(

--- a/v2/theme.go
+++ b/v2/theme.go
@@ -1,41 +1,31 @@
 package main
 
 import (
-	"image/color"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
 )
 
-type myTheme struct{}
+type myTheme struct {
+	fyne.Theme
+}
 
-var _ fyne.Theme = (*myTheme)(nil)
+func MyTheme() fyne.Theme {
+	return myTheme{theme.DefaultTheme()}
+}
 
 // return bundled font resource
-func (*myTheme) Font(s fyne.TextStyle) fyne.Resource {
+func (t myTheme) Font(s fyne.TextStyle) fyne.Resource {
 	if s.Monospace {
-		return theme.DefaultTheme().Font(s)
+		return t.Theme.Font(s)
 	}
 	if s.Bold {
 		if s.Italic {
-			return theme.DefaultTheme().Font(s)
+			return t.Theme.Font(s)
 		}
 		return resourceMplus1cBoldTtf
 	}
 	if s.Italic {
-		return theme.DefaultTheme().Font(s)
+		return t.Theme.Font(s)
 	}
 	return resourceMplus1cRegularTtf
-}
-
-func (*myTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.Color {
-	return theme.DefaultTheme().Color(n, v)
-}
-
-func (*myTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
-	return theme.DefaultTheme().Icon(n)
-}
-
-func (*myTheme) Size(n fyne.ThemeSizeName) float32 {
-	return theme.DefaultTheme().Size(n)
 }


### PR DESCRIPTION
Simplify the code: by embedding a default implementation, there is no need to implement all methods of fyne.Theme.